### PR TITLE
Defense Skill Added. json

### DIFF
--- a/qr-scout-config.json
+++ b/qr-scout-config.json
@@ -296,6 +296,19 @@
                     "defaultValue": "0"
                 },
                 {
+                    "code": "defenseSkill",
+                    "title": "Defense Skill",
+                    "type": "select",
+                    "choices": {
+                        "0": "No defense",
+                        "1": "Ineffective",
+                        "2": "Somewhat effective",
+                        "3": "Very effective"
+                    },
+                    "required": false,
+                    "defaultValue": "0"
+                },  
+                {
                     "code": "defensePlayed",
                     "title": "Defense Played",
                     "type": "select",

--- a/qr-scout-config.json
+++ b/qr-scout-config.json
@@ -124,7 +124,7 @@
                 },
                 {
                     "code": "autoSpeaker",
-                    "title": "Speaker Scored",
+                    "title": "Auto Speaker Scored",
                     "type": "counter",
                     "defaultValue": 0,
                     "min": 0,
@@ -132,7 +132,7 @@
                 },
                 {
                     "code": "autoAmp",
-                    "title": "Amp Scored",
+                    "title": "Auto Amp Scored",
                     "type": "counter",
                     "defaultValue": 0,
                     "min": 0,


### PR DESCRIPTION
Another choice, defense skill was added before defense played. The choices are no defense, uneffective, somewhat effective, and very effective. The autonomous speaker and amp questions also had the word "Auto" added in front of them so it would be easier to keep track of teleop and auto.
![image](https://github.com/FRC-Team-333-The-Megalodons/qr-scout-2024/assets/161899545/acc3a8c9-22d4-4c4b-afe5-6196acd84e26)
